### PR TITLE
Add mutliqueues support for task monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/evo-company/darq_ui/releases/tag/v0.0.X)
 
+* Add multiple queues monitoring support.
+
 ## [0.0.1](https://github.com/evo-company/darq_ui/releases/tag/v0.0.1)
 
 * Initial implementation which contains integrations for `aiohttp` and `fastapi`
-

--- a/client/src/TasksControlPanel/index.jsx
+++ b/client/src/TasksControlPanel/index.jsx
@@ -64,6 +64,7 @@ const formatDoc = (doc) =>
 const TaskInfo = ({ task }) => (
   <Space direction="vertical">
     <div>Status: {task.status || "N/A"}</div>
+    <div>Queue: {task.queue || "N/A"}</div>
     <div>
       Signature: <pre>{formatSignature(task.signature)}</pre>
     </div>

--- a/src/darq_ui/handlers.py
+++ b/src/darq_ui/handlers.py
@@ -1,14 +1,13 @@
 import json
 import logging
 import pkgutil
-
-from typing import Generic, TypeVar
 from dataclasses import dataclass
-from pydantic import BaseModel
+from typing import Generic, TypeVar
 
 from darq.app import Darq
-from darq_ui.darq import Task, TaskStatus
-from darq_ui.darq import DarqHelper
+from pydantic import BaseModel
+
+from darq_ui.darq import DarqHelper, Task, TaskStatus
 from darq_ui.utils import DarqUIConfig, join_url
 
 log = logging.getLogger(__name__)
@@ -52,6 +51,7 @@ class TaskBody(BaseModel):
     docstring: str | None
     status: TaskStatus | None
     dropped_reason: str | None
+    queue: str | None
 
     class Config:
         use_enum_values = True
@@ -101,9 +101,12 @@ def get_index_page(ui_config: DarqUIConfig) -> str | None:
     return page.decode("utf-8")
 
 
-async def get_tasks(darq_app: Darq) -> list[Task]:
+async def get_tasks(
+    darq_app: Darq,
+    queues: list[str] | None = None,
+) -> list[Task]:
     darq_helper = DarqHelper(darq_app)
-    return await darq_helper.get_darq_tasks_for_admin()
+    return await darq_helper.get_darq_tasks_for_admin(queues)
 
 
 async def run_task(

--- a/src/darq_ui/utils.py
+++ b/src/darq_ui/utils.py
@@ -1,13 +1,17 @@
 from dataclasses import dataclass
 
+from darq.constants import default_queue_name
+
 DARQ_APP: str = "_darq_app"
 DARQ_UI_CONFIG: str = "_darq_ui_config"
+DEFAULT_QUEUES = [default_queue_name]
 
 
 @dataclass
 class DarqUIConfig:
     base_path: str
     logs_url: str | None
+    queues: list[str]
     embed: bool = False
 
     def to_dict(self) -> dict:
@@ -15,6 +19,7 @@ class DarqUIConfig:
             "base_path": self.base_path,
             "logs_url": self.logs_url,
             "embed": self.embed,
+            "queues": self.queues,
         }
 
 


### PR DESCRIPTION
So far darq-ui could fetch only status of jobs from default queue. Added support for multiple queues.

Darq doesn't store queue name for a task anywhere so to avoid changing darq codebase I made it so that list of queues is passed to setup